### PR TITLE
Fix issue with unknown events (hotfix)

### DIFF
--- a/src/services/Parser.js
+++ b/src/services/Parser.js
@@ -181,8 +181,10 @@ class Parser {
             embed.color = colors.issueOpenEvent;
         } else if (data.object_attributes.action === 'reopen') {
             embed.title += `Issue reopened: #${data.object_attributes.iid} ${this.formatString(data.object_attributes.title)}`;
-        } else { // Issue close
+        }  else if (data.object_attributes.action === 'close') { // Issue close
             embed.title += `Issue closed: #${data.object_attributes.iid} ${this.formatString(data.object_attributes.title)}`;
+        } else {
+            return;
         }
         return embed;
     }
@@ -204,8 +206,10 @@ class Parser {
             embed.color = colors.mergeOpenEvent;
         } else if (data.object_attributes.action === 'reopen') {
             embed.title += `Merge Request reopened: #${data.object_attributes.iid} ${this.formatString(data.object_attributes.title)}`;
-        } else { // PR close
+        } else if (data.object_attributes.action === 'close') { // PR close
             embed.title += `Merge Request closed: #${data.object_attributes.iid} ${this.formatString(data.object_attributes.title)}`;
+        } else {
+            return;
         }
 
         return embed;

--- a/src/services/Parser.js
+++ b/src/services/Parser.js
@@ -181,7 +181,7 @@ class Parser {
             embed.color = colors.issueOpenEvent;
         } else if (data.object_attributes.action === 'reopen') {
             embed.title += `Issue reopened: #${data.object_attributes.iid} ${this.formatString(data.object_attributes.title)}`;
-        }  else if (data.object_attributes.action === 'close') { // Issue close
+        } else if (data.object_attributes.action === 'close') { // Issue close
             embed.title += `Issue closed: #${data.object_attributes.iid} ${this.formatString(data.object_attributes.title)}`;
         } else {
             return;


### PR DESCRIPTION
This pull request fixes an issue where unknown events to the router will register as a "close" event, since it is not pulling up with the logic in the if/elseif statements currently in place, so it'll think it's close.
This PR explicitly checks if the **Merge Request** and **Issue** is a close event, and will treat as such. If it doesn't recognize any of the other events that are currently in place, it will simply `return`.