### PR TITLE
Fix issue with unknown events (hotfix & attempt #2)

### DIFF
--- a/src/services/Parser.js
+++ b/src/services/Parser.js
@@ -181,8 +181,10 @@ class Parser {
             embed.color = colors.issueOpenEvent;
         } else if (data.object_attributes.action === 'reopen') {
             embed.title += `Issue reopened: #${data.object_attributes.iid} ${this.formatString(data.object_attributes.title)}`;
-        } else { // Issue close
+        }  else if (data.object_attributes.action === 'close') { // Issue close
             embed.title += `Issue closed: #${data.object_attributes.iid} ${this.formatString(data.object_attributes.title)}`;
+        } else {
+            return;
         }
         return embed;
     }
@@ -204,8 +206,10 @@ class Parser {
             embed.color = colors.mergeOpenEvent;
         } else if (data.object_attributes.action === 'reopen') {
             embed.title += `Merge Request reopened: #${data.object_attributes.iid} ${this.formatString(data.object_attributes.title)}`;
-        } else { // PR close
+        } else if (data.object_attributes.action === 'close') { // PR close
             embed.title += `Merge Request closed: #${data.object_attributes.iid} ${this.formatString(data.object_attributes.title)}`;
+        } else {
+            return;
         }
 
         return embed;

--- a/src/services/Parser.js
+++ b/src/services/Parser.js
@@ -181,7 +181,7 @@ class Parser {
             embed.color = colors.issueOpenEvent;
         } else if (data.object_attributes.action === 'reopen') {
             embed.title += `Issue reopened: #${data.object_attributes.iid} ${this.formatString(data.object_attributes.title)}`;
-        }  else if (data.object_attributes.action === 'close') { // Issue close
+        } else if (data.object_attributes.action === 'close') { // Issue close
             embed.title += `Issue closed: #${data.object_attributes.iid} ${this.formatString(data.object_attributes.title)}`;
         } else {
             return;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1331,8 +1331,8 @@ lodash.isequal@^4.0.0:
   resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
 
 lodash.merge@^4.6.0:
-  version "4.6.1"
-  resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.1.tgz#adc25d9cb99b9391c59624f379fbba60d7111d54"
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
 
 lodash@^4.17.10, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.3.0:
   version "4.17.15"

--- a/yarn.lock
+++ b/yarn.lock
@@ -626,12 +626,14 @@ eslint-scope@^4.0.0:
     estraverse "^4.1.1"
 
 eslint-utils@^1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-1.3.1.tgz#9a851ba89ee7c460346f97cf8939c7298827e512"
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-1.4.2.tgz#166a5180ef6ab7eb462f162fd0e6f2463d7309ab"
+  dependencies:
+    eslint-visitor-keys "^1.0.0"
 
 eslint-visitor-keys@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#3f3180fb2e291017716acb4c9d6d5b5c34a6a81d"
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz#e2a82cea84ff246ad6fb57f9bde5b46621459ec2"
 
 eslint@^5.4.0:
   version "5.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1269,8 +1269,8 @@ js-tokens@^3.0.2:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
 js-yaml@^3.11.0:
-  version "3.12.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.12.0.tgz#eaed656ec8344f10f527c6bfa1b6e2244de167d1"
+  version "3.13.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1335,8 +1335,8 @@ lodash.merge@^4.6.0:
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.1.tgz#adc25d9cb99b9391c59624f379fbba60d7111d54"
 
 lodash@^4.17.10, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.3.0:
-  version "4.17.10"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
+  version "4.17.15"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
 
 map-cache@^0.2.2:
   version "0.2.2"


### PR DESCRIPTION
This pull request fixes an issue where unknown events to the router will register as a "close" event, since it is not pulling up with the logic in the if/elseif statements currently in place, so it'll think it's close.
This PR explicitly checks if the **Merge Request** and **Issue** is a close event, and will treat as such. If it doesn't recognize any of the other events that are currently in place, it will simply `return`.