### PR TITLE
feat: Multi-nerwork

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -11,7 +11,7 @@ const { IPBanHandler } = require('./services/IPBanHandler');
 
 const config = require('../configs/config.json');
 
-const routes = require('./routes/index');
+const { router } = require('./routes/router');
 
 // const
 const app = express();
@@ -31,7 +31,7 @@ app.use( (req, res) => {
         return;
     }
 
-    routes.router(req, res);
+    router(req, res);
 } );
 
 app.listen(config.port, Logger.notice(`Listening to port ${config.port}`) );

--- a/src/routes/github.js
+++ b/src/routes/github.js
@@ -6,7 +6,6 @@ const config = require('../../configs/config.json');
 const { Logger }  = require('../utils/Logger');
 
 const { IPBanHandler } = require('../services/IPBanHandler');
-const { RequestManager } = require('../services/requester/RequestManager');
 
 const { verifyGithubSignature, UNAUTHORIZED_CODE } = require('../utils/utils');
 
@@ -41,7 +40,7 @@ function constructHeaders(reqHeaders) {
     return headers;
 }
 
-const github = async(req, res) => {
+const github = async(manager, network, req, res) => {
     // Checking whether the authenticity of the connection is valid
     if (!req.headers['x-github-delivery']
         || (config.auth && !req.headers['x-hub-signature'] )
@@ -71,7 +70,7 @@ const github = async(req, res) => {
     // Creating new headers
     const headers = constructHeaders(req.headers);
 
-    RequestManager.request( { headers, body: req.body }, true);
+    manager.execute(network, { headers, body: req.body }, true);
 };
 
-exports.github = github;
+module.exports = github;

--- a/src/routes/gitlab.js
+++ b/src/routes/gitlab.js
@@ -7,12 +7,11 @@ const { Logger } = require('../utils/Logger');
 const { UNAUTHORIZED_CODE } = require('../utils/utils');
 
 const { IPBanHandler } = require('../services/IPBanHandler');
-const { RequestManager } = require('../services/requester/RequestManager');
 
 const { GitlabParser } = require('../services/parsers/GitlabParser');
 const parser = new GitlabParser();
 
-const gitlab = async(req, res) => {
+const gitlab = async(manager, network, req, res) => {
     if (!req.headers['x-gitlab-event']
         || (config.auth && !req.headers['x-gitlab-token'] )
         || (config.auth && req.headers['x-gitlab-token'] !== config.authorizationGitlab) ) {
@@ -40,7 +39,7 @@ const gitlab = async(req, res) => {
 
     const headers = { 'Content-Type': 'application/json' };
 
-    RequestManager.request( { headers, body: discordRequest } );
+    manager.execute(network, { headers, body: discordRequest } );
 };
 
-exports.gitlab = gitlab;
+module.exports = gitlab;

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -1,36 +1,4 @@
 'use strict';
 
-// Dependency
-const express = require('express');
-
-// Other
-const { Logger } = require('../utils/Logger');
-const { github } = require('./github');
-const { gitlab } = require('./gitlab');
-// const
-const router = express.Router(); // eslint-disable-line
-
-// BASE URL
-router.get('/', (req, res) => {
-    res.send('Hello World!');
-} );
-
-// Redirecting post requests from base endpoint to github or gitlab functions
-router.post('/', (req, res) => {
-    try {
-        if (req.headers['x-github-delivery'] ) {
-            github(req, res);
-        } else if (req.headers['x-gitlab-event'] ) {
-            gitlab(req, res);
-        }
-    } catch (err) {
-        Logger.error(err.stack);
-    }
-} );
-
-//
-router.post('/github', github);
-
-router.post('/gitlab', gitlab);
-
-exports.router = router;
+exports.github = require('./github');
+exports.gitlab = require('./gitlab');

--- a/src/routes/router.js
+++ b/src/routes/router.js
@@ -1,0 +1,59 @@
+'use strict';
+
+// Dependency
+const express = require('express');
+
+const config = require('../../configs/config.json');
+const webhooks = require('../../configs/webhooks.json');
+
+// Other
+const { NetworkManager } = require('../services/NetworkManager');
+
+const { Logger } = require('../utils/Logger');
+const { github, gitlab } = require('./index');
+// const
+const router = express.Router(); // eslint-disable-line
+
+const DEFAULT = 'default';
+
+if (!config.networks || config.networks.length === 0) {
+    config.networks = [DEFAULT];
+}
+
+for (const webhook of webhooks) {
+    if (!webhook.networks || webhook.networks.length === 0) {
+        webhook.networks = [DEFAULT];
+    }
+}
+
+const networkManager = new NetworkManager(config.networks, webhooks);
+
+router.post('/', (req, res) => {
+    try {
+        if (req.headers['x-github-delivery'] ) {
+            github(networkManager, DEFAULT, req, res);
+        } else if (req.headers['x-gitlab-event'] ) {
+            gitlab(networkManager, DEFAULT, req, res);
+        }
+    } catch (err) {
+        Logger.error(err.stack);
+    }
+} );
+
+router.post('/github', (req, res) => {
+    github(networkManager, DEFAULT, req, res);
+} );
+
+router.post('/gitlab', (req, res) => {
+    gitlab(networkManager, DEFAULT, req, res);
+} );
+
+router.post('/:network/github', (req, res) => {
+    github(networkManager, req.params.network, req, res);
+} );
+
+router.post('/:network/gitlab', (req, res) => {
+    gitlab(networkManager, req.params.network, req, res);
+} );
+
+exports.router = router;

--- a/src/routes/router.js
+++ b/src/routes/router.js
@@ -1,30 +1,37 @@
 'use strict';
 
-// Dependency
 const express = require('express');
 
 const config = require('../../configs/config.json');
 const webhooks = require('../../configs/webhooks.json');
 
-// Other
 const { NetworkManager } = require('../services/NetworkManager');
 
 const { Logger } = require('../utils/Logger');
 const { github, gitlab } = require('./index');
-// const
-const router = express.Router(); // eslint-disable-line
 
+const router = express.Router(); // eslint-disable-line new-cap
 const DEFAULT = 'default';
 
-if (!config.networks || config.networks.length === 0) {
-    config.networks = [DEFAULT];
-}
-
-for (const webhook of webhooks) {
-    if (!webhook.networks || webhook.networks.length === 0) {
-        webhook.networks = [DEFAULT];
+function validateConfig(_config, _webhooks) {
+    if (!_config.networks || _config.networks.length === 0) {
+        _config.networks = [{ name: DEFAULT }];
+    }
+    
+    for (const webhook of _webhooks) {
+        if (!webhook.networks || webhook.networks.length === 0) {
+            webhook.networks = [DEFAULT];
+        } else if (!_config.networks.some(n => webhook.networks.includes(n.name) ) ) {
+            webhook.networks.push(DEFAULT);
+        }
+    }
+    
+    if (_webhooks.find(w => w.networks.includes(DEFAULT) ) && !_config.networks.find(n => n.name === DEFAULT) ) {
+        _config.networks.push( { name: DEFAULT } );
     }
 }
+
+validateConfig(config, webhooks);
 
 const networkManager = new NetworkManager(config.networks, webhooks);
 

--- a/src/services/NetworkManager.js
+++ b/src/services/NetworkManager.js
@@ -1,0 +1,36 @@
+'use strict';
+
+const { RequestManager } = require('./requester/RequestManager');
+const { RequestHandler } = require('./requester/RequestHandler');
+const { Webhook } = require('./Webhook');
+
+class NetworkManager {
+    constructor(networks, webhooks) {
+        this.requester = new RequestHandler();
+
+        this.networks = new Map();
+
+        const _network = {};
+        for (const network of networks) {
+            _network[network] = [];
+        }
+
+        for (const webhook of webhooks) {
+            for (const network of webhook.networks) {
+                if (_network[network] ) {
+                    _network[network] = new Webhook(webhook.name, webhook.id, webhook.token);
+                }
+            }
+        }
+
+        for (const network of networks) {
+            this.networks.set(network, new RequestManager(_network[network], this.requester) );
+        }
+    }
+
+    execute(network, data, type) {
+        this.networks.get(network).request(data, type);
+    }
+}
+
+exports.NetworkManager = NetworkManager;

--- a/src/services/NetworkManager.js
+++ b/src/services/NetworkManager.js
@@ -10,26 +10,31 @@ class NetworkManager {
 
         this.networks = new Map();
 
-        const _network = {};
+        const _networks = {};
         for (const network of networks) {
-            _network[network] = [];
+            _networks[network.name] = [];
         }
 
         for (const webhook of webhooks) {
             for (const network of webhook.networks) {
-                if (_network[network] ) {
-                    _network[network] = new Webhook(webhook.name, webhook.id, webhook.token);
+                if (_networks[network] ) {
+                    _networks[network].push(new Webhook(webhook.name, webhook.id, webhook.token) );
                 }
             }
         }
 
         for (const network of networks) {
-            this.networks.set(network, new RequestManager(_network[network], this.requester) );
+            this.networks.set(network.name, new RequestManager(_networks[network.name], this.requester) );
         }
     }
 
     execute(network, data, type) {
-        this.networks.get(network).request(data, type);
+        const requester = this.networks.get(network);
+        if (!requester) {
+            console.log(`Invalid network ${network}`);
+            return;
+        }
+        requester.request(data, type);
     }
 }
 

--- a/src/services/Webhook.js
+++ b/src/services/Webhook.js
@@ -1,0 +1,19 @@
+'use strict';
+
+class Webhook {
+    constructor(name, id, token) {
+        this.name = name;
+        this._id = id;
+        this._token = token;
+    }
+
+    get id() {
+        return this._id;
+    }
+
+    get token() {
+        return this._token;
+    }
+}
+
+exports.Webhook = Webhook;

--- a/src/services/requester/RequestManager.js
+++ b/src/services/requester/RequestManager.js
@@ -5,14 +5,12 @@ const { RequestHandler } = require('./RequestHandler');
 
 const { Logger } = require('../../utils/Logger');
 
-const WEBHOOKS = require('../../../configs/webhooks.json');
-
 class RequestManager {
-    constructor(webhooks) {
+    constructor(webhooks, requestHandler) {
         this._webhooks = webhooks;
         this._executors = new Map();
 
-        this.requester = new RequestHandler();
+        this.requester = requestHandler || new RequestHandler();
     }
 
     /**
@@ -66,4 +64,4 @@ class RequestManager {
     }
 }
 
-exports.RequestManager = new RequestManager(WEBHOOKS);
+exports.RequestManager = RequestManager;

--- a/template/config.template.json
+++ b/template/config.template.json
@@ -3,5 +3,17 @@
     "auth": true,
     "authorizationGithub": "secret",
     "authorizationGitlab": "secret",
-    "blacklisted": ["ip", "ip"]
+    "blacklisted": ["ip", "ip"],
+    "networks": [
+        {
+            "name": "network1",
+            "authorizationGithub": "secret",
+            "authorizationGitlab": "secret"
+        },
+        {
+            "name": "network2",
+            "authorizationGithub": "secret",
+            "authorizationGitlab": "secret"
+        }
+    ]
 }

--- a/template/webhooks.template.json
+++ b/template/webhooks.template.json
@@ -2,11 +2,13 @@
     {
         "name": "webhook",
         "id": "webhookID",
-        "token": "webhookToken"
+        "token": "webhookToken",
+        "networks": ["network1", "network2"]
     },
     {
         "name": "webhook2",
         "id": "webhookID",
-        "token": "webhookToken"
+        "token": "webhookToken",
+        "networks": ["network1", "network2"]
     }
 ]


### PR DESCRIPTION
This PR brings support to a multi network configuration.
This PR keeps backward compatibility, which means old config design should work as expected.

Networks should be added in two places:
Appended in config:
```json
networks: [
  {
      "name": "network1",
      "authorizationGithub": "secret",
      "authorizationGitlab": "secret"
  },
]
```

Appended in webhooks:
```json
"networks": []
```

This allow the same webhook to be in multiple network.
This allows to have a gitlab/github secret token per network.
It will fallback to the global authorisation if not specified

Closes #10 