### PR TITLE
refactor/fix: Security update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+GITLAB: headers: x-gitlab-token => not encoded 
+
 # Git-Discord-HookRouter
 Manage all your GitHub / GitLab webhooks with one URL.  
 This lightweight API allows you to route GitHub and GitLab webhook requests to Discord. Allows easy management of multiple webhooks.

--- a/src/app.js
+++ b/src/app.js
@@ -1,29 +1,23 @@
 'use strict';
-// Dependencies
 const express = require('express');
 const bodyParser = require('body-parser');
 
-// Others
 const { Logger } = require('./utils/Logger.js');
-const { UNAUTHORIZED_CODE } = require('./utils/utils');
-
+const { getIP, UNAUTHORIZED_CODE } = require('./utils/utils');
 const { IPBanHandler } = require('./services/IPBanHandler');
 
 const config = require('../configs/config.json');
-
 const { router } = require('./routes/router');
 
-// const
 const app = express();
 
 app.use(bodyParser.json() );
 app.use(bodyParser.urlencoded( { extended: true } ) );
 
+// Handle banned ips - then reroute to the correct endpoint
 app.use( (req, res) => {
     // IP should always exist
-    const ip = (req.headers['x-forwarded-for'] && req.headers['x-forwarded-for'].split(',')[0] )
-        || req.ip
-        || (req.connection && req.connection.remoteAddress);
+    const ip = getIP(req);
 
     if (!ip || IPBanHandler.banned.has(ip) ) {
         res.status(UNAUTHORIZED_CODE).send('Unauthorized');
@@ -34,4 +28,4 @@ app.use( (req, res) => {
     router(req, res);
 } );
 
-app.listen(config.port, Logger.notice(`Listening to port ${config.port}`) );
+app.listen(config.port, Logger.notice(`Listening on port ${config.port}`) );

--- a/src/routes/router.js
+++ b/src/routes/router.js
@@ -12,6 +12,8 @@ const { github, gitlab } = require('./index');
 
 const router = express.Router(); // eslint-disable-line new-cap
 const DEFAULT = 'default';
+const GITHUB_TYPE = 0;
+const GITLAB_TYPE = 1;
 
 function validateConfig(_config, _webhooks) {
     if (!_config.networks || _config.networks.length === 0) {
@@ -31,6 +33,28 @@ function validateConfig(_config, _webhooks) {
     }
 }
 
+function getNetworkAndAuth(curNetwork, _config, type) {
+    let auth = (type === GITHUB_TYPE)
+        ? _config.authorizationGithub
+        : _config.authorizationGitlab;
+
+    const networkObj = _config.networks.find(e => e.name === curNetwork);
+    if (networkObj) {
+        // If the auth property exist, we will use it. If you want to use the global auth for this network, don't setup the auth property at all
+        // If the auth property is empty, it will consider the network doesn't have any auth
+        if (type === GITHUB_TYPE && (networkObj.authorizationGithub !== undefined) ) {
+            auth = networkObj.authorizationGithub;
+        } else if (type === GITLAB_TYPE && (networkObj.authorizationGitlab !== undefined) ) {
+            auth = networkObj.authorizationGitlab;
+        }
+    }
+
+    return {
+        network: curNetwork,
+        auth,
+    };
+}
+
 validateConfig(config, webhooks);
 
 const networkManager = new NetworkManager(config.networks, webhooks);
@@ -38,9 +62,11 @@ const networkManager = new NetworkManager(config.networks, webhooks);
 router.post('/', (req, res) => {
     try {
         if (req.headers['x-github-delivery'] ) {
-            github(networkManager, DEFAULT, req, res);
+            github(networkManager, getNetworkAndAuth(DEFAULT, config, GITHUB_TYPE), req, res);
         } else if (req.headers['x-gitlab-event'] ) {
-            gitlab(networkManager, DEFAULT, req, res);
+            gitlab(networkManager, getNetworkAndAuth(DEFAULT, config, GITLAB_TYPE), req, res);
+        } else {
+            Logger.error('Invalid source.');
         }
     } catch (err) {
         Logger.error(err.stack);
@@ -48,19 +74,21 @@ router.post('/', (req, res) => {
 } );
 
 router.post('/github', (req, res) => {
-    github(networkManager, DEFAULT, req, res);
+    github(networkManager, getNetworkAndAuth(DEFAULT, config, GITHUB_TYPE), req, res);
 } );
 
 router.post('/gitlab', (req, res) => {
-    gitlab(networkManager, DEFAULT, req, res);
+    gitlab(networkManager, getNetworkAndAuth(DEFAULT, config, GITLAB_TYPE), req, res);
 } );
 
 router.post('/:network/github', (req, res) => {
-    github(networkManager, req.params.network, req, res);
+    const { network } = req.params;
+    github(networkManager, getNetworkAndAuth(network, config, GITHUB_TYPE), req, res);
 } );
 
 router.post('/:network/gitlab', (req, res) => {
-    gitlab(networkManager, req.params.network, req, res);
+    const { network } = req.params;
+    gitlab(networkManager, getNetworkAndAuth(network, config, GITLAB_TYPE), req, res);
 } );
 
 exports.router = router;

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -1,17 +1,19 @@
 'use strict';
 
-// Dependency
 const { createHmac, timingSafeEqual } = require('crypto');
 
-// Others
-const config = require('../../configs/config.json');
-
-const verifyGithubSignature = function verifyGithubSignature(signature, payloadBody) {
-    const HMAC = `sha1=${createHmac('sha1', config.authorizationGithub)
+function verifyGithubSignature(signature, payloadBody, auth) {
+    const HMAC = `sha1=${createHmac('sha1', auth)
         .update(JSON.stringify(payloadBody) )
         .digest('hex')}`;
     return timingSafeEqual(Buffer.from(signature), Buffer.from(HMAC) );
-};
+}
+
+function getIP(req) {
+    return (req.headers['x-forwarded-for'] && req.headers['x-forwarded-for'].split(',')[0] )
+        || req.ip
+        || (req.connection && req.connection.remoteAddress);
+}
 
 /** Wait for a delay in ms*/
 const sleep = (ms) => new Promise( (res) => setTimeout( () => res(), ms) );
@@ -21,6 +23,7 @@ const UNAUTHORIZED_CODE = 403;
 
 module.exports = {
     verifyGithubSignature,
+    getIP,
     sleep,
     RATELIMIT_CODE,
     UNAUTHORIZED_CODE,


### PR DESCRIPTION
Included in this PR:

- Fix all auth check.
- Enable full auth support
- Per network auth support
- No auth support

This PR add support for per network auth. It also fix all auth routes to make sure auth works correctly.
Important to note: Gitlab doesn't encode the auth token, while github does.

With this PR you can have specific network auth token. Or you can use the default one. Specificying the auth to an empty string disable auth check for this network